### PR TITLE
feat: backend CRUD módulo tareas comerciales

### DIFF
--- a/CRM/src/app/services/clientes.service.ts
+++ b/CRM/src/app/services/clientes.service.ts
@@ -1,4 +1,4 @@
-import { Injectable } from '@angular/core';
+import { Injectable, inject } from '@angular/core';
 import { HttpClient, HttpParams } from '@angular/common/http';
 import { Observable } from 'rxjs';
 import { Cliente } from '../models/cliente.model';
@@ -7,24 +7,36 @@ import { Cliente } from '../models/cliente.model';
   providedIn: 'root'
 })
 export class ClientesService {
+  private http = inject(HttpClient);
+  private baseUrl = 'http://localhost:8080/api/clientes';
 
-  private baseUrl = 'http://localhost:8080/api/clientes'; // cambia el puerto si hace falta
-
-  constructor(private http: HttpClient) {}
-
-  // filtros básicos: nombre y cif
+  // 1. Listar con filtros
   getClientes(filtros?: { nombre?: string; cif?: string }): Observable<Cliente[]> {
     let params = new HttpParams();
-
     if (filtros) {
-      if (filtros.nombre) {
-        params = params.set('nombre', filtros.nombre);
-      }
-      if (filtros.cif) {
-        params = params.set('cif', filtros.cif);
-      }
+      if (filtros.nombre) params = params.set('nombre', filtros.nombre);
+      if (filtros.cif) params = params.set('cif', filtros.cif);
     }
-
     return this.http.get<Cliente[]>(this.baseUrl, { params });
+  }
+
+  // 2. Obtener un solo cliente (para edición)
+  getCliente(id: number): Observable<Cliente> {
+    return this.http.get<Cliente>(`${this.baseUrl}/${id}`);
+  }
+
+  // 3. Crear cliente (POST)
+  crearCliente(cliente: Cliente): Observable<Cliente> {
+    return this.http.post<Cliente>(this.baseUrl, cliente);
+  }
+
+  // 4. Actualizar cliente (PUT)
+  actualizarCliente(id: number, cliente: Cliente): Observable<Cliente> {
+    return this.http.put<Cliente>(`${this.baseUrl}/${id}`, cliente);
+  }
+
+  // 5. Eliminar (DELETE)
+  eliminarCliente(id: number): Observable<void> {
+    return this.http.delete<void>(`${this.baseUrl}/${id}`);
   }
 }

--- a/crm-backend/src/main/java/com/dam2/crm/controller/TareaController.java
+++ b/crm-backend/src/main/java/com/dam2/crm/controller/TareaController.java
@@ -1,0 +1,72 @@
+package com.dam2.crm.controller;
+
+import com.dam2.crm.model.Tarea;
+import com.dam2.crm.service.TareaService;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.*;
+
+import java.util.List;
+
+@RestController
+@RequestMapping("/api/tareas")
+@CrossOrigin(origins = "http://localhost:4200") // Importante para Angular
+public class TareaController {
+
+    @Autowired
+    private TareaService tareaService;
+
+    @GetMapping
+    public List<Tarea> getAllTareas() {
+        return tareaService.findAll();
+    }
+
+    @GetMapping("/usuario/{usuarioId}")
+    public List<Tarea> getTareasByUsuario(@PathVariable Long usuarioId) {
+        return tareaService.findByUsuario(usuarioId);
+    }
+    
+    @GetMapping("/cliente/{clienteId}")
+    public List<Tarea> getTareasByCliente(@PathVariable Long clienteId) {
+        return tareaService.findByCliente(clienteId);
+    }
+
+    @GetMapping("/{id}")
+    public ResponseEntity<Tarea> getTareaById(@PathVariable Long id) {
+        return tareaService.findById(id)
+                .map(tarea -> new ResponseEntity<>(tarea, HttpStatus.OK))
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    @PostMapping
+    public ResponseEntity<Tarea> createTarea(@RequestBody Tarea tarea) {
+        // Aquí podrías validar que el cliente y usuario existen si no vienen completos
+        return new ResponseEntity<>(tareaService.save(tarea), HttpStatus.CREATED);
+    }
+
+    @PutMapping("/{id}")
+    public ResponseEntity<Tarea> updateTarea(@PathVariable Long id, @RequestBody Tarea tareaDetails) {
+        return tareaService.findById(id)
+                .map(tarea -> {
+                    tarea.setTitulo(tareaDetails.getTitulo());
+                    tarea.setDescripcion(tareaDetails.getDescripcion());
+                    tarea.setFechaVencimiento(tareaDetails.getFechaVencimiento());
+                    tarea.setEstado(tareaDetails.getEstado());
+                    tarea.setCliente(tareaDetails.getCliente());
+                    // No solemos cambiar el usuario asignado en un update simple, pero se podría
+                    return new ResponseEntity<>(tareaService.save(tarea), HttpStatus.OK);
+                })
+                .orElse(new ResponseEntity<>(HttpStatus.NOT_FOUND));
+    }
+
+    @DeleteMapping("/{id}")
+    public ResponseEntity<Void> deleteTarea(@PathVariable Long id) {
+        if (tareaService.findById(id).isPresent()) {
+            tareaService.deleteById(id);
+            return new ResponseEntity<>(HttpStatus.NO_CONTENT);
+        } else {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
+    }
+}

--- a/crm-backend/src/main/java/com/dam2/crm/model/EstadoTarea.java
+++ b/crm-backend/src/main/java/com/dam2/crm/model/EstadoTarea.java
@@ -1,0 +1,8 @@
+package com.dam2.crm.model;
+
+public enum EstadoTarea {
+    PENDIENTE,
+    EN_PROCESO,
+    COMPLETADA,
+    CANCELADA
+}

--- a/crm-backend/src/main/java/com/dam2/crm/model/Tarea.java
+++ b/crm-backend/src/main/java/com/dam2/crm/model/Tarea.java
@@ -1,0 +1,43 @@
+package com.dam2.crm.model;
+
+import jakarta.persistence.*;
+import lombok.AllArgsConstructor;
+import lombok.Builder;
+import lombok.Data;
+import lombok.NoArgsConstructor;
+
+import java.time.LocalDate;
+
+@Data
+@Builder
+@NoArgsConstructor
+@AllArgsConstructor
+@Entity
+@Table(name = "tareas")
+public class Tarea {
+
+    @Id
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private Long id;
+
+    @Column(nullable = false)
+    private String titulo;
+
+    private String descripcion;
+
+    @Column(name = "fecha_vencimiento")
+    private LocalDate fechaVencimiento;
+
+    @Enumerated(EnumType.STRING)
+    private EstadoTarea estado;
+
+    // Relación con Cliente (Muchas tareas -> Un cliente)
+    @ManyToOne
+    @JoinColumn(name = "cliente_id", nullable = false)
+    private Cliente cliente;
+
+    // Relación con Usuario (Muchas tareas -> Un usuario)
+    @ManyToOne
+    @JoinColumn(name = "usuario_id", nullable = false)
+    private User usuario;
+}

--- a/crm-backend/src/main/java/com/dam2/crm/repository/TareaRepository.java
+++ b/crm-backend/src/main/java/com/dam2/crm/repository/TareaRepository.java
@@ -1,0 +1,19 @@
+package com.dam2.crm.repository;
+
+import com.dam2.crm.model.Tarea;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+import java.util.List;
+
+@Repository
+public interface TareaRepository extends JpaRepository<Tarea, Long> {
+    // Buscar tareas de un usuario concreto
+    List<Tarea> findByUsuarioId(Long usuarioId);
+    
+    // Buscar tareas asociadas a un cliente
+    List<Tarea> findByClienteId(Long clienteId);
+    
+    // Buscar por estado
+    List<Tarea> findByEstado(String estado);
+}

--- a/crm-backend/src/main/java/com/dam2/crm/service/TareaService.java
+++ b/crm-backend/src/main/java/com/dam2/crm/service/TareaService.java
@@ -1,0 +1,14 @@
+package com.dam2.crm.service;
+
+import com.dam2.crm.model.Tarea;
+import java.util.List;
+import java.util.Optional;
+
+public interface TareaService {
+    List<Tarea> findAll();
+    List<Tarea> findByUsuario(Long usuarioId);
+    List<Tarea> findByCliente(Long clienteId);
+    Optional<Tarea> findById(Long id);
+    Tarea save(Tarea tarea);
+    void deleteById(Long id);
+}

--- a/crm-backend/src/main/java/com/dam2/crm/service/TareaServiceImpl.java
+++ b/crm-backend/src/main/java/com/dam2/crm/service/TareaServiceImpl.java
@@ -1,0 +1,46 @@
+package com.dam2.crm.service;
+
+import com.dam2.crm.model.Tarea;
+import com.dam2.crm.repository.TareaRepository;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+import java.util.Optional;
+
+@Service
+public class TareaServiceImpl implements TareaService {
+
+    @Autowired
+    private TareaRepository tareaRepository;
+
+    @Override
+    public List<Tarea> findAll() {
+        return tareaRepository.findAll();
+    }
+
+    @Override
+    public List<Tarea> findByUsuario(Long usuarioId) {
+        return tareaRepository.findByUsuarioId(usuarioId);
+    }
+
+    @Override
+    public List<Tarea> findByCliente(Long clienteId) {
+        return tareaRepository.findByClienteId(clienteId);
+    }
+
+    @Override
+    public Optional<Tarea> findById(Long id) {
+        return tareaRepository.findById(id);
+    }
+
+    @Override
+    public Tarea save(Tarea tarea) {
+        return tareaRepository.save(tarea);
+    }
+
+    @Override
+    public void deleteById(Long id) {
+        tareaRepository.deleteById(id);
+    }
+}


### PR DESCRIPTION
Implementación completa del backend para la gestión de Tareas Comerciales (Issue #8).

Cambios realizados:
- Modelo: Creada entidad 'Tarea' con relaciones @ManyToOne hacia 'Cliente' y 'User'.
- Enum: Creado 'EstadoTarea' (PENDIENTE, EN_PROCESO, COMPLETADA, CANCELADA).
- Repositorio: Añadidos métodos de búsqueda por 'usuarioId' y 'clienteId'.
- Servicio: Lógica de negocio para CRUD completo.
- Controlador: Expuestos endpoints REST en '/api/tareas' con configuración @CrossOrigin.

Funcionalidades habilitadas:
- Listar todas las tareas.
- Filtrar tareas por usuario (comercial) o por cliente.
- Crear, editar y eliminar tareas.